### PR TITLE
Run Exe as Admin

### DIFF
--- a/build.spec
+++ b/build.spec
@@ -16,5 +16,6 @@ exe = EXE(pyz,
           a.zipfiles,
           a.datas,
           console=False,
+          uac_admin=True,
           name='CursedMage',
           icon='app/assets/images/team_logo.ico')


### PR DESCRIPTION
Exe will now need to be run as admin. Not sure if we keep this forever but fixes permission errors for the team